### PR TITLE
[jdbc-scala] New debuging utility in the AcolyteDSL.

### DIFF
--- a/jdbc-scala/src/main/scala/jdbc/Execution.scala
+++ b/jdbc-scala/src/main/scala/jdbc/Execution.scala
@@ -11,6 +11,12 @@ sealed trait Execution {
   def parameters: List[ExecutedParameter]
 }
 
+/**
+ * Information about the execution of a query.
+ * 
+ * @param sql the SQL statement
+ * @param parameter the parameters the query is executed with
+ */
 case class QueryExecution(
   sql: String, parameters: List[ExecutedParameter] = Nil) extends Execution
 
@@ -28,7 +34,11 @@ case class ExecutedStatement(val p: String) {
     re.findFirstIn(x.sql).map(_ ⇒ (x.sql -> x.parameters))
 }
 
-sealed trait ExecutedParameter { def value: Any }
+/** Parameter used to executed a query or an update. */
+sealed trait ExecutedParameter {
+  /** The parameter value */
+  def value: Any
+}
 
 /** Executed parameter companion */
 object ExecutedParameter {

--- a/jdbc-scala/src/test/scala/acolyte/jdbc/ConnectionSpec.scala
+++ b/jdbc-scala/src/test/scala/acolyte/jdbc/ConnectionSpec.scala
@@ -16,4 +16,25 @@ object ConnectionSpec extends org.specs2.mutable.Specification {
 
     }
   }
+
+  "Debug" should {
+    "be successful" in {
+      val output = Seq.newBuilder[String]
+
+      AcolyteDSL.debuging(output += _.toString) { con =>
+        val stmt = con.prepareStatement("SELECT * FROM Test WHERE id = ?")
+
+        try {
+          stmt.setString(1, "foo")
+          stmt.executeQuery()
+        } catch {
+          case e: java.sql.SQLException => ()
+        } finally {
+          stmt.close()
+        }
+      }
+
+      output.result() must_== Seq("QueryExecution(SELECT * FROM Test WHERE id = ?,List(Param(foo, VARCHAR)))")
+    }
+  }
 }

--- a/project/Acolyte.scala
+++ b/project/Acolyte.scala
@@ -20,7 +20,7 @@ object Acolyte extends Build with Dependencies
       jdbcDriver, jdbcScala, jdbcClojure, studio).
     settings(
       organization in ThisBuild := "org.eu.acolyte",
-      version in ThisBuild := s"1.0.33${versionVariant}",
+      version in ThisBuild := s"1.0.34${versionVariant}",
       javaOptions in ThisBuild ++= Seq(
         "-source", javaVersion, "-target", javaVersion),
       scalaVersion in ThisBuild := "2.10.4",

--- a/src/site/markdown/java.md
+++ b/src/site/markdown/java.md
@@ -16,6 +16,8 @@ With Maven 2/3+, its dependency can be resolved in the following way:
   </dependencies>
 ```
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.eu.acolyte/jdbc-driver/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.eu.acolyte/jdbc-driver/)
+
 Then code could be:
 
 ```java

--- a/src/site/markdown/scala.md
+++ b/src/site/markdown/scala.md
@@ -8,6 +8,8 @@ Using SBT, Acolyte JDBC dependency can resolved as following:
 libraryDependencies += "org.eu.acolyte" %% "jdbc-scala" % "VERSION" % "test"
 ```
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.eu.acolyte/jdbc-scala_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.eu.acolyte/jdbc-scala_2.11/)
+
 Then code could be:
 
 ```scala
@@ -299,3 +301,31 @@ val uh1: UpdateExecution => UpdateResult =
   // Defined from UpdateExecution => Int
   { ex: UpdateExecution => /* update count = */ 2 }
 ```
+
+## Debug utility
+
+Acolyte can be use to create [scope of debuging](http://acolyte.eu.org/jdbc-scaladoc/#acolyte.jdbc.AcolyteDSL$@debuging[A]%28printer:QueryExecution=%3EUnit%29%28f:SqlConnection=%3EA%29:Unit), to check what is executed in the JDBC layer.
+
+```scala
+import acolyte.jdbc.AcolyteDSL
+
+AcolyteDSL.debuging() { con =>
+  val stmt = con.prepareStatement("SELECT * FROM Test WHERE id = ?")
+  stmt.setString(1, "foo")
+  stmt.executeQuery()
+}
+```
+
+The previous example will print `Executed query: QueryExecution(SELECT * FROM Test WHERE id = ?,List(Param(foo, VARCHAR)))`  on the stdout.
+
+The default printer (using stdout) can be replaced by any function `acolyte.jdbc.QueryExecution => Unit` (see [`QueryExecution`](http://acolyte.eu.org/jdbc-scaladoc/#acolyte.jdbc.QueryExecution) API).
+
+```scala
+import acolyte.jdbc.AcolyteDSL
+
+AcolyteDSL.debuging({ exec => myLogger.debug(s"Executed: $exec") }) { con =>
+  ???
+}
+```
+
+> Any function using JDBC which is called within the scope, will be passed to the debug printer.


### PR DESCRIPTION
Create a debug scope, to print/debug any JDBC execution within it:

```scala
AcolyteDSL.debuging() { con =>
  val stmt = con.prepareStatement("SELECT * FROM Test WHERE id = ?")
  stmt.setString(1, "foo")
  stmt.executeQuery()
}
```

> Print `"Executed query: QueryExecution(SELECT * FROM Test WHERE id = ?,List(Param(foo, VARCHAR)))"` using the default debug printer (can be customized).