### PR TITLE
Support reactivemongo 0.11.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ jdk:
    - openjdk6
    - oraclejdk8
 env: JAVA_OPTS="-Xms32m -Xmx128m"
+before_install:
+- sudo ./.travis_scripts/beforeInstall.sh $TRAVIS_SCALA_VERSION
 scala:
    - 2.11.7

--- a/.travis_scripts/beforeInstall.sh
+++ b/.travis_scripts/beforeInstall.sh
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+# Travis OpenJDK workaround
+cat /etc/hosts # optionally check the content *before*
+hostname "$(hostname | cut -c1-63)"
+sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | tee /etc/hosts
+cat /etc/hosts # optionally check the content *after*

--- a/project/ReactiveMongo.scala
+++ b/project/ReactiveMongo.scala
@@ -34,7 +34,7 @@ trait ReactiveMongo { deps: Dependencies ⇒
         },
       resolvers ++= reactiveResolvers,
       libraryDependencies ++= Seq(
-        "org.reactivemongo" %% "reactivemongo" % "0.10.5.0.akka23",
+        "org.reactivemongo" %% "reactivemongo" % "0.11.9",
         "com.jsuereth" %% "scala-arm" % "1.4",
         "com.chuusai" % "shapeless" % "2.0.0" % Test cross CrossVersion.
           binaryMapped {

--- a/reactive-mongo/src/main/scala/acolyte/reactivemongo/DriverManager.scala
+++ b/reactive-mongo/src/main/scala/acolyte/reactivemongo/DriverManager.scala
@@ -17,7 +17,7 @@ object DriverManager {
 
   /** Manager instance based on connection handler. */
   implicit object Default extends DriverManager {
-    def open = new MongoDriver(Some(Akka.actorSystem()))
+    def open = MongoDriver()
 
     /** Releases driver if necessary. */
     def releaseIfNecessary(driver: MongoDriver): Boolean = try {
@@ -43,7 +43,6 @@ trait ConnectionManager[T] {
 /** Connection manage companion. */
 object ConnectionManager {
   import akka.actor.Props
-  import reactivemongo.core.actors.MonitorActor
   import reactivemongo.api.MongoConnectionOptions
 
   /** Manager instance based on connection handler. */
@@ -52,9 +51,9 @@ object ConnectionManager {
 
     def open(driver: MongoDriver, handler: ConnectionHandler) = {
       val sys = driver.system
-      val actor = sys.actorOf(Props(classOf[Actor], handler))
-      val monitor = sys.actorOf(Props(new MonitorActor(actor)))
-      new MongoConnection(sys, actor, monitor, MongoConnectionOptions())
+      val actorRef = sys.actorOf(Props(classOf[Actor], handler))
+
+      new MongoConnection(sys, actorRef, MongoConnectionOptions())
     }
 
     /** Releases connection if necessary. */

--- a/reactive-mongo/src/main/scala/acolyte/reactivemongo/WithCollection.scala
+++ b/reactive-mongo/src/main/scala/acolyte/reactivemongo/WithCollection.scala
@@ -1,7 +1,7 @@
 package acolyte.reactivemongo
 
 import scala.concurrent.{ ExecutionContext, Future }
-import reactivemongo.api.collections.default.BSONCollection
+import reactivemongo.api.collections.bson.BSONCollection
 import reactivemongo.api.{ DB, MongoConnection, MongoDriver }
 
 /** Functions to work with a Mongo collection (provided DB functions). */


### PR DESCRIPTION
When running with latest reactivemongo, I get 
java.lang.ClassCastException: akka.actor.ActorSystemImpl cannot be cast to com.typesafe.config.Config
	at reactivemongo.api.MongoDriver.<init>(api.scala:566)
	at acolyte.reactivemongo.DriverManager$Default$.open(DriverManager.scala:20)
	at acolyte.reactivemongo.WithDriver$$anonfun$withFlatDriver$1.apply(WithDriver.scala:57)
	at acolyte.reactivemongo.WithDriver$$anonfun$withFlatDriver$1.apply(WithDriver.scala:57)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
...

In 0.10.5 MongoDriver used to take ActorSystem parameter (https://github.com/ReactiveMongo/ReactiveMongo/blob/0.10.5.x.akka23/driver/src/main/scala/api/api.scala) but now it takes a Config instead (https://github.com/ReactiveMongo/ReactiveMongo/blob/5c8dc95e5cf92564fd6a2696c917c752be6ff3b2/driver/src/main/scala/api/api.scala)