### PR TITLE
Add resource handler parameter for AcolyteDatabase

### DIFF
--- a/play-jdbc/src/main/scala/AcolyteDatabase.scala
+++ b/play-jdbc/src/main/scala/AcolyteDatabase.scala
@@ -10,7 +10,9 @@ import java.sql.{ Connection, DriverManager }
 import play.api.db.Database
 
 import acolyte.jdbc.{
+  ConnectionHandler,
   Driver ⇒ AcolyteDriver,
+  ResourceHandler,
   ScalaCompositeHandler
 }
 
@@ -22,9 +24,10 @@ import acolyte.jdbc.{
  */
 final class AcolyteDatabase(
     handler: ScalaCompositeHandler,
+    resourceHanndler: ResourceHandler = new ResourceHandler.Default(),
     id: String = java.util.UUID.randomUUID().toString) extends Database { self ⇒
 
-  AcolyteDriver.register(id, handler)
+  AcolyteDriver.register(id, new ConnectionHandler.Default(handler, resourceHanndler))
 
   val name = s"acolyte-$id"
 

--- a/play-jdbc/src/main/scala/AcolyteDatabase.scala
+++ b/play-jdbc/src/main/scala/AcolyteDatabase.scala
@@ -24,10 +24,10 @@ import acolyte.jdbc.{
  */
 final class AcolyteDatabase(
     handler: ScalaCompositeHandler,
-    resourceHanndler: ResourceHandler = new ResourceHandler.Default(),
+    resourceHandler: ResourceHandler = new ResourceHandler.Default(),
     id: String = java.util.UUID.randomUUID().toString) extends Database { self ⇒
 
-  AcolyteDriver.register(id, new ConnectionHandler.Default(handler, resourceHanndler))
+  AcolyteDriver.register(id, new ConnectionHandler.Default(handler, resourceHandler))
 
   val name = s"acolyte-$id"
 

--- a/play-jdbc/src/main/scala/PlayJdbcDSL.scala
+++ b/play-jdbc/src/main/scala/PlayJdbcDSL.scala
@@ -1,7 +1,7 @@
 // -*- mode: scala -*-
 package acolyte.jdbc.play
 
-import acolyte.jdbc.{ AcolyteDSL, QueryResult, ScalaCompositeHandler }
+import acolyte.jdbc.{ AcolyteDSL, QueryResult, ResourceHandler, ScalaCompositeHandler }
 
 import play.api.db.Database
 
@@ -52,13 +52,15 @@ object PlayJdbcDSL {
 }
 
 /** Acolyte handler for Play JDBC. */
-final class PlayJdbcContext(handler: ScalaCompositeHandler) {
+final class PlayJdbcContext(
+    handler: ScalaCompositeHandler,
+    resourceHandler: ResourceHandler = new ResourceHandler.Default()) {
 
   /**
    * @param f the function applied on the Acolyte/Play `Database`
    */
   def apply[A](f: Database ⇒ A): A = {
-    lazy val db = new AcolyteDatabase(handler)
+    lazy val db = new AcolyteDatabase(handler, resourceHandler)
 
     try {
       f(db)

--- a/play-jdbc/src/test/scala/PlayJdbcSpec.scala
+++ b/play-jdbc/src/test/scala/PlayJdbcSpec.scala
@@ -1,9 +1,7 @@
 package acolyte.jdbc.play
 
-import play.api.db.Database
 import anorm._
-
-import acolyte.jdbc.Implicits._
+import play.api.db.Database
 
 class PlaySpec extends org.specs2.mutable.Specification {
   "Acolyte/Play JDBC" title
@@ -11,12 +9,46 @@ class PlaySpec extends org.specs2.mutable.Specification {
   sequential
 
   "Anorm use case #1" should {
-    val runner1 = PlayJdbcDSL.withPlayDBResult("foo")
+    val runner1 = PlayJdbcUseCases.useCase1
 
     "return a DB related string" in runner1 { db: Database ⇒
       db.withConnection { implicit con ⇒
         SQL"SELECT test".as(SqlParser.scalar[String].single) must_== "foo"
       }
+    }
+  }
+
+  "Anorm use case #2" should {
+    @volatile var count = 0
+    val runner2 = PlayJdbcUseCases.useCase2 { count = count + 1 }
+
+    "should increment count on commit" in runner2 { db: Database ⇒
+      db.withConnection { implicit con ⇒
+        con.setAutoCommit(false)
+        SQL"insert into foo values (1, 'foo value')".executeInsert() must beSome(1)
+        SQL"insert into bar values (1, 'bar value')".executeInsert() must beSome(1)
+        con.commit()
+      }
+      count must_== 1
+    }
+  }
+
+  "Anorm use case #3" should {
+    @volatile var count = 1
+    val runner3 = PlayJdbcUseCases.useCase3 { count = count - 1 }
+
+    "should decrement count on rollback" in runner3 { db: Database ⇒
+      db.withConnection { implicit con ⇒
+        con.setAutoCommit(false)
+        try {
+          SQL"insert into foo values (1, 'foo value')".executeInsert() must beSome(1)
+          SQL"insert into bar values (1, 'bar value')".executeInsert() must throwA[java.sql.SQLException]("Simulating on error.")
+          throw new IllegalStateException("Stopping transaction")
+        } catch {
+          case _: Throwable ⇒ con.rollback()
+        }
+      }
+      count must_== 0
     }
   }
 }

--- a/play-jdbc/src/test/scala/PlayJdbcUseCases.scala
+++ b/play-jdbc/src/test/scala/PlayJdbcUseCases.scala
@@ -1,0 +1,33 @@
+package acolyte.jdbc.play
+
+import java.sql.SQLException
+
+import acolyte.jdbc.{ AcolyteDSL, RowLists }
+import acolyte.jdbc.UpdateExecution
+import acolyte.jdbc.Implicits._
+
+case object PlayJdbcUseCases {
+
+  val useCase1: PlayJdbcContext = PlayJdbcDSL.withPlayDBResult("foo")
+
+  def useCase2(onUpdate: ⇒ Unit): PlayJdbcContext = new PlayJdbcContext(
+    AcolyteDSL.handleStatement.withUpdateHandler {
+      case UpdateExecution("insert into foo values (1, 'foo value')", Nil) ⇒
+        AcolyteDSL.updateResult(1, RowLists.longList.append(1L))
+      case UpdateExecution("insert into bar values (1, 'bar value')", Nil) ⇒
+        AcolyteDSL.updateResult(2, RowLists.longList.append(1L))
+      case u ⇒ throw new SQLException(s"Unexpected update: $u")
+    },
+    AcolyteDSL.handleTransaction(whenCommit = { _ ⇒ onUpdate }))
+
+  def useCase3(onUpdate: ⇒ Unit): PlayJdbcContext = new PlayJdbcContext(
+    AcolyteDSL.handleStatement.withUpdateHandler {
+      case UpdateExecution("insert into foo values (1, 'foo value')", Nil) ⇒
+        AcolyteDSL.updateResult(1, RowLists.longList.append(1L))
+      case UpdateExecution("insert into bar values (1, 'bar value')", Nil) ⇒
+        throw new SQLException("Simulating on error.")
+      case u ⇒ throw new SQLException(s"Unexpected update: $u")
+    },
+    AcolyteDSL.handleTransaction(whenRollback = { _ ⇒ onUpdate }))
+
+}


### PR DESCRIPTION
Add a `ResourceHandler` parameter for `AcolyteDatabase`. I propagate it until the `PlayJdbcContext` (not sure if I have to continue `PlayJdbcDSL` methods).